### PR TITLE
Add kata generation script

### DIFF
--- a/generate_katas.py
+++ b/generate_katas.py
@@ -1,0 +1,295 @@
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if PyYAML not installed
+    yaml = None
+
+TEMPLATE_PATH = Path("templates/kata-template.yaml")
+PATTERNS_SPEC = Path("specs/kata-patterns-spec.yaml")
+COMPLEXITY_SPEC = Path("specs/kata-complexity-spec.yaml")
+OUTPUT_DIR = Path("katas")
+
+LEVEL_MAP = {
+    "explore": 1,
+    "tinker": 2,
+    "contribute": 3,
+    "engineer": 4,
+    "architect": 5,
+}
+
+
+def _basic_yaml_load(text: str) -> dict:
+    """Very small YAML subset parser used if PyYAML is unavailable."""
+    result: dict[str, object] = {}
+    stack: list[object] = [result]
+    indents = [0]
+    key_stack: list[str | None] = [None]
+
+    def add_to_parent(key: str, value: object) -> None:
+        parent = stack[-1]
+        if isinstance(parent, dict):
+            parent[key] = value
+        elif isinstance(parent, list):
+            parent.append({key: value})
+
+    lines = [ln.rstrip("\n") for ln in text.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    for idx, line in enumerate(lines):
+        indent = len(line) - len(line.lstrip(" "))
+        while indent < indents[-1]:
+            stack.pop()
+            indents.pop()
+            key_stack.pop()
+        line = line.strip()
+        if line.startswith("- "):
+            item: dict[str, object] = {}
+            parent = stack[-1]
+            if not isinstance(parent, list):
+                lst: list[object] = []
+                if isinstance(parent, dict):
+                    k = key_stack[-1]
+                    if k:
+                        parent[k] = lst
+                stack.append(lst)
+                indents.append(indent)
+                key_stack.append(None)
+                parent = lst
+            parent.append(item)
+            stack.append(item)
+            indents.append(indent + 2)
+            key_stack.append(None)
+        else:
+            if ":" in line:
+                k, v = line.split(":", 1)
+                k = k.strip()
+                v = v.strip()
+                if not v:
+                    next_line = lines[idx + 1].lstrip() if idx + 1 < len(lines) else ""
+                    if next_line.startswith("- "):
+                        d: list[object] = []
+                    else:
+                        d = {}
+                    add_to_parent(k, d)
+                    stack.append(d)
+                    indents.append(indent + 2)
+                    key_stack.append(k)
+                else:
+                    if v.startswith("[") and v.endswith("]"):
+                        items = [i.strip().strip('"') for i in v[1:-1].split(",") if i.strip()]
+                        add_to_parent(k, items)
+                    else:
+                        add_to_parent(k, v.strip('"'))
+                    key_stack[-1] = k
+    return result
+
+
+def load_yaml(path: Path) -> dict:
+    text = path.read_text()
+    if yaml is not None:
+        return yaml.safe_load(text)
+    if path == PATTERNS_SPEC:
+        return {"kata_patterns": _parse_kata_patterns(path)}
+    if path == TEMPLATE_PATH:
+        return {"kata": _parse_template(path)}
+    try:
+        import json
+        return json.loads(text)
+    except Exception:
+        return _basic_yaml_load(text)
+
+
+def _dict_to_yaml(data: object, indent: int = 0) -> list[str]:
+    spaces = " " * indent
+    lines: list[str] = []
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if isinstance(v, (dict, list)):
+                lines.append(f"{spaces}{k}:")
+                lines.extend(_dict_to_yaml(v, indent + 2))
+            else:
+                if isinstance(v, str):
+                    lines.append(f"{spaces}{k}: '{v}'")
+                else:
+                    lines.append(f"{spaces}{k}: {v}")
+    elif isinstance(data, list):
+        for item in data:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{spaces}-")
+                lines.extend(_dict_to_yaml(item, indent + 2))
+            else:
+                if isinstance(item, str):
+                    lines.append(f"{spaces}- '{item}'")
+                else:
+                    lines.append(f"{spaces}- {item}")
+    return lines
+
+
+def dump_yaml(data: object, path: Path) -> None:
+    if yaml is not None:
+        with path.open("w") as f:
+            yaml.safe_dump(data, f, sort_keys=False)
+    else:
+        import json
+        with path.open("w") as f:
+            json.dump(data, f)
+
+
+def _parse_kata_patterns(path: Path) -> list[dict]:
+    patterns = []
+    current: dict[str, object] | None = None
+    list_key: str | None = None
+    for line in path.read_text().splitlines():
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        if line.startswith("  - name:"):
+            if current:
+                patterns.append(current)
+            current = {
+                "name": line.split(":", 1)[1].strip().strip('"')
+            }
+            list_key = None
+            continue
+        if current is None:
+            continue
+        if line.startswith("    "):
+            content = line.strip()
+            if content.endswith(":"):
+                list_key = content[:-1]
+                current[list_key] = []
+            elif content.startswith("- ") and list_key:
+                current[list_key].append(content[2:].strip().strip('"'))
+            else:
+                if ":" in content:
+                    key, val = content.split(":", 1)
+                    val = val.strip()
+                    if val.startswith("[") and val.endswith("]"):
+                        items = [i.strip().strip('"') for i in val[1:-1].split(",") if i.strip()]
+                        current[key.strip()] = items
+                    else:
+                        current[key.strip()] = val.strip('"')
+                list_key = None
+    if current:
+        patterns.append(current)
+    return patterns
+
+
+def _parse_template(path: Path) -> dict:
+    template: dict[str, object] = {}
+    in_kata = False
+    current_list: str | None = None
+    for line in path.read_text().splitlines():
+        if line.strip().startswith("kata:"):
+            in_kata = True
+            continue
+        if not in_kata:
+            continue
+        if not line.startswith("  "):
+            break
+        stripped = line.strip()
+        if stripped.endswith(":"):
+            current_list = stripped[:-1]
+            template[current_list] = []
+        elif stripped.startswith("- ") and current_list:
+            template[current_list].append(stripped[2:].strip().strip('"'))
+        elif ":" in stripped:
+            key, val = stripped.split(":", 1)
+            template[key.strip()] = val.strip().strip('"')
+            current_list = None
+    return template
+
+
+def load_specs():
+    if yaml is not None:
+        patterns = load_yaml(PATTERNS_SPEC).get("kata_patterns", [])
+        complexity = load_yaml(COMPLEXITY_SPEC).get("complexity_indicators", [])
+    else:
+        patterns = _parse_kata_patterns(PATTERNS_SPEC)
+        complexity = []
+    return patterns, complexity
+
+
+def load_template() -> dict:
+    if yaml is not None:
+        data = load_yaml(TEMPLATE_PATH)
+        return data.get("kata", data)
+    return _parse_template(TEMPLATE_PATH)
+
+
+def level_to_num(level: str) -> int:
+    return LEVEL_MAP.get(level.lower(), 1)
+
+
+def map_finding_to_kata(finding: dict, template: dict, patterns_spec: list) -> dict:
+    name = finding.get("name") or finding.get("pattern") or str(finding.get("_name", "Unknown"))
+    spec = next(
+        (p for p in patterns_spec if p.get("name", "").lower() in name.lower()),
+        None,
+    )
+    kata = deepcopy(template)
+    kata["title"] = name
+    if spec:
+        kata["type"] = spec.get("kata_type", kata.get("type"))
+        kata["skill_domains"] = spec.get("skill_domains", kata.get("skill_domains", []))
+        level = spec.get("progression_level", kata.get("progression_level", "explore"))
+    else:
+        level = kata.get("progression_level", "explore")
+    kata["progression_level"] = level_to_num(level)
+
+    meta = kata.setdefault("metadata", {})
+    if finding.get("file"):
+        meta["source_file"] = finding.get("file")
+    if finding.get("function"):
+        meta["source_function"] = finding.get("function")
+    return kata
+
+
+def generate_kata_file(analysis_path: str, repo_name: str | None = None) -> Path:
+    analysis_data = json.loads(Path(analysis_path).read_text())
+    patterns_spec, _ = load_specs()
+    template = load_template()
+
+    if repo_name is None:
+        repo_name = Path(analysis_path).stem.replace("-analysis", "")
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    output_file = OUTPUT_DIR / f"{repo_name}-katas.yaml"
+
+    findings = []
+    for key in ("patterns", "smells"):
+        items = analysis_data.get(key, [])
+        for item in items:
+            if isinstance(item, str):
+                item = {"name": item}
+            findings.append(item)
+
+    katas = []
+    seen = set()
+    for finding in findings:
+        key = (finding.get("file"), finding.get("function"))
+        if key in seen:
+            continue
+        seen.add(key)
+        katas.append(map_finding_to_kata(finding, template, patterns_spec))
+
+    # group by progression level
+    katas.sort(key=lambda k: k.get("progression_level", 1))
+
+    dump_yaml({"katas": katas}, output_file)
+
+    return output_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate kata progression file from analysis JSON")
+    parser.add_argument("analysis", help="Path to analysis JSON file")
+    parser.add_argument("--repo-name", help="Name of repository", default=None)
+    args = parser.parse_args()
+
+    output = generate_kata_file(args.analysis, args.repo_name)
+    print(f"Kata file generated at {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.57.1",
+    "PyYAML>=6.0",
 ]
 
 [dependency-groups]

--- a/tests/test_generate_katas.py
+++ b/tests/test_generate_katas.py
@@ -1,0 +1,27 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from generate_katas import generate_kata_file, load_yaml
+
+
+def test_generate_kata_file(tmp_path):
+    analysis = {
+        "patterns": [{"name": "Complex Function", "file": "app.py", "function": "foo"}],
+        "smells": [],
+    }
+    analysis_file = tmp_path / "repo-analysis.json"
+    analysis_file.write_text(json.dumps(analysis))
+
+    output = generate_kata_file(str(analysis_file), repo_name="repo")
+    assert output.exists()
+
+    data = load_yaml(Path(output))
+    assert data["katas"]
+    kata = data["katas"][0]
+    assert kata["title"] == "Complex Function"
+    assert kata["metadata"]["source_file"] == "app.py"
+    assert kata["metadata"]["source_function"] == "foo"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -18,7 +19,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "anthropic", specifier = ">=0.57.1" }]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.57.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -381,6 +385,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- generate kata progression YAML/JSON from analysis results
- provide minimal YAML parsing fallback if PyYAML unavailable
- include basic unit test for kata generator
- require PyYAML dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a19c54f8832d878dd75c7a0b0d35